### PR TITLE
Add pagination

### DIFF
--- a/src/main/kotlin/com/edd/memegrid/memes/MemeManager.kt
+++ b/src/main/kotlin/com/edd/memegrid/memes/MemeManager.kt
@@ -49,10 +49,10 @@ class MemeManager(
     /**
      * @return list of latest memes from database.
      */
-    fun getMemes() = transaction(database) {
+    fun getMemes(page: Int = 0) = transaction(database) {
         StoredMemes
                 .selectAll()
-                .limit(maxMemes)
+                .limit(maxMemes, page * maxMemes)
                 .orderBy(StoredMemes.id, isAsc = false)
                 .map(::map)
     }

--- a/src/main/kotlin/com/edd/memegrid/util/BadPageException.kt
+++ b/src/main/kotlin/com/edd/memegrid/util/BadPageException.kt
@@ -1,0 +1,3 @@
+package com.edd.memegrid.util
+
+class BadPageException(message : String) : Exception(message)

--- a/src/main/kotlin/com/edd/memegrid/util/Http.kt
+++ b/src/main/kotlin/com/edd/memegrid/util/Http.kt
@@ -54,6 +54,14 @@ val Request.jsonBody
     get() = JSONObject(body())
 
 /**
+ * @return parameter as an Int number.
+ */
+infix fun Request.intParam(name: String): Int = params(name)
+        .trim()
+        .toIntOrNull()
+        ?: throw BadPageException("Parameter $name must be a number")
+
+/**
  * @return parameter as a Long number.
  */
 infix fun Request.longParam(name: String): Long = params(name)

--- a/src/main/kotlin/com/edd/memegrid/web/Router.kt
+++ b/src/main/kotlin/com/edd/memegrid/web/Router.kt
@@ -3,6 +3,7 @@ package com.edd.memegrid.web
 import com.edd.memegrid.memes.Meme
 import com.edd.memegrid.memes.MemeManager
 import com.edd.memegrid.util.BadMemeException
+import com.edd.memegrid.util.BadPageException
 import com.edd.memegrid.util.ImageValidator
 import com.edd.memegrid.util.MEDIA_TYPE_HTML
 import com.edd.memegrid.util.MEDIA_TYPE_JSON
@@ -17,6 +18,7 @@ import com.edd.memegrid.util.accept
 import com.edd.memegrid.util.deleteJson
 import com.edd.memegrid.util.getJson
 import com.edd.memegrid.util.html
+import com.edd.memegrid.util.intParam
 import com.edd.memegrid.util.json
 import com.edd.memegrid.util.jsonBody
 import com.edd.memegrid.util.jsonError
@@ -61,6 +63,10 @@ class Router(
 
         getJson("/api/memes") { _, _ ->
             memeManager.getMemes().json
+        }
+
+        getJson("/api/memes/page/:page") { req, _ ->
+            memeManager.getMemes(req intParam "page").json
         }
 
         getJson("/api/memes/:id") { req, _ ->
@@ -111,6 +117,7 @@ class Router(
 
         MemeNotFoundException::class jsonException STATUS_CODE_NOT_FOUND
         BadMemeException::class jsonException STATUS_CODE_BAD_REQUEST
+        BadPageException::class jsonException STATUS_CODE_BAD_REQUEST
         JSONException::class jsonException STATUS_CODE_BAD_REQUEST
 
         exception(Exception::class.java) { e, req, res ->

--- a/src/main/resources/public/static/index.css
+++ b/src/main/resources/public/static/index.css
@@ -1,3 +1,7 @@
+html {
+  min-height: 101%;
+}
+
 .header {
   overflow: hidden;
   position: fixed;

--- a/src/main/resources/public/static/index.js
+++ b/src/main/resources/public/static/index.js
@@ -60,11 +60,40 @@ window.onload = () => {
     });
   };
 
-  fetch('/api/memes')
-    .then(response => response.json())
-    .then(mapImages)
-    .then(showImages)
-    .catch(() => {
-      grid.innerText = 'Memes could not be fetched :(';
-    });
+  let isLoading = false;
+  let isCompleted = false;
+  let currentPage = 0;
+
+  const loadImages = () => {
+    if (isLoading || isCompleted) return;
+    isLoading = true;
+
+    fetch('/api/memes/page/' + currentPage)
+      .then(response => response.json())
+      .then(images => {
+        currentPage++;
+        isCompleted = images.length === 0;
+        if (isCompleted) {
+          window.onscroll = null;
+        }
+
+        return images;
+      })
+      .then(mapImages)
+      .then(showImages)
+      .catch(() => {
+        grid.innerText = 'Memes could not be fetched :(';
+      })
+      .finally(() => {
+        isLoading = false;
+      });
+  };
+
+  loadImages();
+
+  window.onscroll = () => {
+    if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
+      loadImages();
+    }
+  }
 };


### PR DESCRIPTION
Add support for pagination and uses that in the browser. Prevents flooding of the server by not sending new requests when the previous one has not been completed. Also stops listening to scroll events completely when the last item has been received.